### PR TITLE
fix: clear stale login error after successful registration

### DIFF
--- a/gallery/src/pages/Signin.jsx
+++ b/gallery/src/pages/Signin.jsx
@@ -1,44 +1,47 @@
-import {useState}  from 'react'
-import {Link, useNavigate} from 'react-router-dom'
+import { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { signInStart, signInSuccess, signInFailure } from '../redux/user/userSlice.jsx'
+import { signInStart, signInSuccess, signInFailure, clearError } from '../redux/user/userSlice.jsx';
 import OAuth from '../components/OAuth.jsx';
 import { TERipple } from "tw-elements-react";
+
 export default function SignIn() {
-  const [formData, setFormData]= useState({});
-  const { loading, error } = useSelector((state) => state.user)
+  const [formData, setFormData] = useState({});
+  const { loading, error } = useSelector((state) => state.user);
   const navigate = useNavigate();
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(clearError());
+  }, [dispatch]);
 
   const handleChnage = (e) => {
     setFormData({
       ...formData,
-      [e.target.id] : e.target.value,
+      [e.target.id]: e.target.value,
     });
-  }
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    
+
     try {
       dispatch(signInStart());
-      const res = await fetch('/api/auth/signin',  {
+      const res = await fetch('/api/auth/signin', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-
-        body: JSON.stringify(formData)
+        body: JSON.stringify(formData),
       });
       const data = await res.json();
-      // console.log(data);
-      if(data.success === false) {
+      if (data.success === false) {
         dispatch(signInFailure(data.message));
         return;
       }
       dispatch(signInSuccess(data));
       navigate('/');
-    } catch(error) {
+    } catch (error) {
       dispatch(signInFailure(error.message));
     }
   };
@@ -65,13 +68,31 @@ export default function SignIn() {
                       </h4>
                     </div>
 
-                    {error && <p className='text-red-500 mt-5'>{error}</p>}
-                      {/* <p className="mb-4">Please login to your account</p> */}
-                    <form onSubmit={handleSubmit} className='flex flex-col gap-4 pb-2'>
-                      <input type="email" placeholder='email' className='border p-3 rounded-lg' id='email' onChange={handleChnage}/>
-                      <input type="password" placeholder='password' className='border p-3 rounded-lg' id='password' onChange={handleChnage}/>
-                      <button disabled={loading} className='bg-red-500 text-white p-3 rounded-lg uppercase hover:opacity-90'>{loading ? 'Loading...' : 'Sign In'}</button>
+                    {error && <p className="text-red-500 mt-5">{error}</p>}
+
+                    <form onSubmit={handleSubmit} className="flex flex-col gap-4 pb-2">
+                      <input
+                        type="email"
+                        placeholder="email"
+                        className="border p-3 rounded-lg"
+                        id="email"
+                        onChange={handleChnage}
+                      />
+                      <input
+                        type="password"
+                        placeholder="password"
+                        className="border p-3 rounded-lg"
+                        id="password"
+                        onChange={handleChnage}
+                      />
+                      <button
+                        disabled={loading}
+                        className="bg-red-500 text-white p-3 rounded-lg uppercase hover:opacity-90"
+                      >
+                        {loading ? 'Loading...' : 'Sign In'}
+                      </button>
                     </form>
+
                     <div className="flex items-center justify-between pb-1">
                       <p className="mb-0 mr-2">Don&apos;t have an account?</p>
                       <Link to={'/sign-up'}>
@@ -86,8 +107,8 @@ export default function SignIn() {
                       </Link>
                     </div>
 
-                    <div className='flex flex-col gap-4 pb-3'>
-                      <p className='mb-1 pt-1 text-center'>Or</p>
+                    <div className="flex flex-col gap-4 pb-3">
+                      <p className="mb-1 pt-1 text-center">Or</p>
                       <OAuth />
                     </div>
                   </div>
@@ -98,7 +119,7 @@ export default function SignIn() {
                   className="hidden lg:flex items-center rounded-b-lg lg:w-6/12 lg:rounded-r-lg lg:rounded-bl-none"
                   style={{
                     background:
-                      "linear-gradient(to right, #ee7724, #d8363a, #dd3675, #b44593)",
+                      'linear-gradient(to right, #ee7724, #d8363a, #dd3675, #b44593)',
                   }}
                 >
                   <div className="px-4 py-6 text-white md:mx-6 md:p-12">
@@ -117,5 +138,5 @@ export default function SignIn() {
         </div>
       </div>
     </section>
-  )
+  );
 }

--- a/gallery/src/redux/user/userSlice.jsx
+++ b/gallery/src/redux/user/userSlice.jsx
@@ -1,8 +1,8 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-    currentUser : null,
-    error : null,
+    currentUser: null,
+    error: null,
     loading: false,
 };
 
@@ -10,29 +10,29 @@ export const userSlice = createSlice({
     name: "user",
     initialState,
     reducers: {
-        signInStart : (state) => {
+        signInStart: (state) => {
             state.loading = true;
         },
-        signInSuccess : (state, action) =>{
+        signInSuccess: (state, action) => {
             state.currentUser = action.payload;
             state.loading = false;
             state.error = null;
         },
-        signInFailure : (state, action) =>{
+        signInFailure: (state, action) => {
             state.error = action.payload;
-            state.loading=false; 
+            state.loading = false;
         },
-        updateUserStart : (state) =>{
-            state.loading= true;
+        updateUserStart: (state) => {
+            state.loading = true;
         },
-        updateUserSuccess : (state, action) =>{
+        updateUserSuccess: (state, action) => {
             state.currentUser = action.payload;
             state.loading = false;
             state.error = null;
         },
-        updateUserFailure : (state, action) =>{
+        updateUserFailure: (state, action) => {
             state.error = action.payload;
-            state.loading=false; 
+            state.loading = false;
         },
         deleteUserStart: (state) => {
             state.loading = true;
@@ -44,7 +44,7 @@ export const userSlice = createSlice({
         },
         deleteUserFailure: (state, action) => {
             state.error = action.payload;
-            state.loading=false; 
+            state.loading = false;
         },
         signoutUserStart: (state) => {
             state.loading = true;
@@ -56,12 +56,29 @@ export const userSlice = createSlice({
         },
         signoutUserFailure: (state, action) => {
             state.error = action.payload;
-            state.loading=false; 
-        }
+            state.loading = false;
+        },
 
+        clearError: (state) => {
+            state.error = null;
+        },
     },
 });
 
-export const { signInStart, signInSuccess, signInFailure, updateUserFailure, updateUserStart, updateUserSuccess, deleteUserFailure, deleteUserStart, deleteUserSuccess, signoutUserFailure, signoutUserStart, signoutUserSuccess } = userSlice.actions;
+export const {
+    signInStart,
+    signInSuccess,
+    signInFailure,
+    updateUserFailure,
+    updateUserStart,
+    updateUserSuccess,
+    deleteUserFailure,
+    deleteUserStart,
+    deleteUserSuccess,
+    signoutUserFailure,
+    signoutUserStart,
+    signoutUserSuccess,
+    clearError,
+} = userSlice.actions;
 
 export default userSlice.reducer;


### PR DESCRIPTION
Closes #25  

This pull request fixes a UI bug where the login error message from a previous failed sign-in attempt persisted even after a successful registration and redirect to the Sign In page.

**Changes Made:**

Added a clearError reducer in userSlice.jsx to reset authentication errors.
Implemented a useEffect in SignIn.jsx to dispatch clearError() when the component mounts, ensuring the login page always loads in a clean state.

**Steps to Verify:**

Attempt to sign in with incorrect credentials → observe the error message.
Navigate to the Sign Up page → complete registration successfully.
After redirection to the Sign In page, confirm that the old error message no longer appears.

**Result:**

The Sign In page now correctly resets its state after a successful registration, improving user experience and reducing confusion.