### PR TITLE
 fix: prefill startDate and endDate in Update Listing form (fixes #21)

### DIFF
--- a/gallery/src/pages/UpdateListing.jsx
+++ b/gallery/src/pages/UpdateListing.jsx
@@ -21,6 +21,8 @@ export default function CreateListing() {
         sponsers_detail : '',
         organizational_detail : '',
         ticketfee : 50,
+        startDate: '',
+        endDate: '',
     });
     
     const [imageUploadError, setImageUploadError] =useState(false);
@@ -38,7 +40,13 @@ export default function CreateListing() {
                 console.log(data.message)
                 return;
             }
-            setFormData(data)
+            // Format dates for input fields (YYYY-MM-DD)
+            const formattedData = {
+                ...data,
+                startDate: data.startDate ? data.startDate.split('T')[0] : '',
+                endDate: data.endDate ? data.endDate.split('T')[0] : '',
+            };
+            setFormData(formattedData)
 
         }
 


### PR DESCRIPTION
Extended Description:
- Added startDate and endDate fields to formData initial state
- Format ISO date strings to YYYY-MM-DD for HTML date inputs
- Dates now prefill correctly when editing existing listings